### PR TITLE
Fix for invalid cookie date time

### DIFF
--- a/CefSharp.Core/ResourceHandlerWrapper.cpp
+++ b/CefSharp.Core/ResourceHandlerWrapper.cpp
@@ -77,39 +77,60 @@ namespace CefSharp
             cookie->Secure = cefCookie.secure == 1;
             cookie->HttpOnly = cefCookie.httponly == 1;
 
-            if (cefCookie.has_expires)
-            {
-                cookie->Expires = DateTime(
-                    cefCookie.expires.year,
-                    cefCookie.expires.month,
-                    cefCookie.expires.day_of_month,
-                    cefCookie.expires.hour,
-                    cefCookie.expires.minute,
-                    cefCookie.expires.second,
-                    cefCookie.expires.millisecond
-                    );
-            }
+			try
+			{
+				if (cefCookie.has_expires)
+				{
+					cookie->Expires = DateTime(
+						cefCookie.expires.year,
+						cefCookie.expires.month,
+						cefCookie.expires.day_of_month,
+						cefCookie.expires.hour,
+						cefCookie.expires.minute,
+						cefCookie.expires.second,
+						cefCookie.expires.millisecond
+						);
+				}
+			}
+			catch (Exception^ ex)
+			{
+				cookie->Expires = DateTime::MinValue;
+			}
 
             //TODO: There is a method in TypeUtils that's in BrowserSubProcess that convers CefTime, need to make it accessible.
-            cookie->Creation = DateTime(
-                cefCookie.creation.year,
-                cefCookie.creation.month,
-                cefCookie.creation.day_of_month,
-                cefCookie.creation.hour,
-                cefCookie.creation.minute,
-                cefCookie.creation.second,
-                cefCookie.creation.millisecond
-                );
+			try
+			{
+				cookie->Creation = DateTime(
+					cefCookie.creation.year,
+					cefCookie.creation.month,
+					cefCookie.creation.day_of_month,
+					cefCookie.creation.hour,
+					cefCookie.creation.minute,
+					cefCookie.creation.second,
+					cefCookie.creation.millisecond
+					);
+			}
+			catch (Exception^ ex)
+			{
+				cookie->Creation = DateTime::MinValue;
+			}
 
-            cookie->LastAccess = DateTime(
-                cefCookie.last_access.year,
-                cefCookie.last_access.month,
-                cefCookie.last_access.day_of_month,
-                cefCookie.last_access.hour,
-                cefCookie.last_access.minute,
-                cefCookie.last_access.second,
-                cefCookie.last_access.millisecond
-                );
+			try
+			{
+				cookie->LastAccess = DateTime(
+					cefCookie.last_access.year,
+					cefCookie.last_access.month,
+					cefCookie.last_access.day_of_month,
+					cefCookie.last_access.hour,
+					cefCookie.last_access.minute,
+					cefCookie.last_access.second,
+					cefCookie.last_access.millisecond
+					);
+			}
+			catch (Exception^ ex)
+			{
+				cookie->LastAccess = DateTime::MinValue;
+			}
         }
 
         return cookie;


### PR DESCRIPTION
Error and stacktrace:

Year, Month, and Day parameters describe an un-representable DateTime.
   at System.DateTime.DateToTicks(Int32 year, Int32 month, Int32 day)
   at System.DateTime..ctor(Int32 year, Int32 month, Int32 day, Int32 hour, Int32 minute, Int32 second, Int32 millisecond)
   at CefSharp.ResourceHandlerWrapper.GetCookie(ResourceHandlerWrapper* , CefStructBase<CefCookieTraits>* cookie)
   at CefSharp.ResourceHandlerWrapper.CanGetCookie(ResourceHandlerWrapper* , CefStructBase<CefCookieTraits>* cookie)

Fixed by copying the same solution found here:

https://github.com/cefsharp/CefSharp/blob/cd934267c65f494ceb9ee75995cd2a1ca0954543/CefSharp.Core/Internals/CookieVisitor.cpp